### PR TITLE
Add schema.org markup to bibcast slides.

### DIFF
--- a/bibcast16/index.html
+++ b/bibcast16/index.html
@@ -15,6 +15,27 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
 
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"type": "PresentationDigitalDocument",
+	"name" : "lobid-organisations: Ein umfassender Index deutscher Informationseinrichtungen",
+	"creator" : {
+		"id": "http://lobid.org/team/ap",
+		"type": "Person",
+		"name": "Adrian Pohl"
+	},
+	"description": "Diese Folien wurden zur Präsentation des eines Vortrags am 9.3.2016 innerhalb der BibCast-Reihe verwendet. URL: http://bibcast.openbiblio.eu/lobid-organisations-ein-umfassender-index-deutscher-informationseinrichtungen/",
+	"about" : [ "lobid", "libraries", "organisation index", "API", "web development"],
+	"url" : "https://hbz.github.io/slides/bibcast16/",
+	"datePublished" : "2016-03-09",
+	"inLanguage" : "de-DE",
+	"audience": [ "web developers", "librarians" ],
+	"isBasedOn": "http://hbz.github.io/slides/swib-15/",
+	"license": "https://creativecommons.org/licenses/by/4.0/"
+}
+</script>
+
 <link rel="stylesheet" href="css/reveal.css">
 <link rel="stylesheet" href="css/theme/hbz.css" id="theme">
 <link rel="stylesheet" href="lib/css/zenburn.css">


### PR DESCRIPTION
@fsteeg Assigning you just for information. I think we should eat our own dog food and add schema.org markup to our slides. I started by adding example markup to bibcast slides. 