### PR TITLE
Add 2021-gndcon-reconcile slides to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,10 @@
 				</div>
 				<table>
 					<tr>
+						<td>2021-06-10</td>
+						<td><a href="https://slides.lobid.org/2021-gndcon-reconcile/">"OpenRefine Reconciliation mit lobid-gnd"</a>, Fabian Steeg. MiniCon <a href="https://wiki.dnb.de/pages/viewpage.action?pageId=202448299">"Wie verlinken wir unsere Daten mit der GND?"</a>, GNDCon 2021, WWW</td>
+					</tr>
+					<tr>
 						<td>2020-11-27</td>
 						<td><a href="https://slides.lobid.org/2020-swib-reconciliation/">"The W3C Entity Reconciliation Community Group"</a>, Fabian Steeg. Lightning Talk at <a href="http://swib.org/swib20/">SWIB20</a>, WWW</td>
 					</tr>


### PR DESCRIPTION
Also review for the actual slides at https://slides.lobid.org/2021-gndcon-reconcile/