### PR TITLE
Add Discourse (and Mastodon)

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,8 +410,9 @@
 					<span class="pull-right">
 						<a href="https://www.hbz-nrw.de/impressum">Impressum</a> | 
 						<a href="https://github.com/hbz/lobid/blob/master/conf/Datenschutzerklaerung_lobid.textile">Datenschutz</a> | 
-						<a href="https://twitter.com/lobidorg"><i class="fa fa-twitter" aria-hidden="true"></i> Twitter</a>&nbsp; 
-						<a href="https://github.com/hbz/slides"><i class="fa fa-github" aria-hidden="true"></i> GitHub</a>&nbsp; 
+						<a href="https://openbiblio.social/@lobid"><i class="fa-brands fa-mastodon" aria-hidden="true"></i> Mastodon</a>&nbsp; 
+						<a href="https://metadaten.community/c/software-und-tools/lobid/10"><i class="fa-brands fa-discourse" aria-hidden="true"></i> Discourse</a>&nbsp; 
+						<a href="https://github.com/hbz/slides"><i class="fa-brands fa-github" aria-hidden="true"></i> GitHub</a>&nbsp; 
 						<a href="http://blog.lobid.org"><i class="fa fa-pencil" aria-hidden="true"></i> Blog</a>
 					</span>
 				</div>


### PR DESCRIPTION
https://github.com/hbz/lobid/issues/526

Since Mastodon is already implemented in lobid.org, I added it here as well.